### PR TITLE
SAI-16: Add graph topology health view

### DIFF
--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -15,8 +15,34 @@ from app.core.permissions import require_role, TokenData
 from app.ingestion.pipeline import pipeline
 from app.vectorstore.faiss_store import FaissStore
 from app.services.embedding import embedding_service
+from app.graph.extractor import graph_extractor
 
 router = APIRouter(tags=["documents"])
+
+
+@router.get("/documents/graph")
+async def get_documents_graph():
+    """Get knowledge graph topology and sanitized health status."""
+    try:
+        return await graph_extractor.get_topology_with_health()
+    except Exception as e:
+        logger.error(f"Graph endpoint error: {e}")
+        return {
+            "nodes": [],
+            "links": [],
+            "health": {
+                "status": "unavailable",
+                "neo4j_available": False,
+                "node_count": 0,
+                "relationship_count": 0,
+                "document_count": 0,
+                "chunk_count": 0,
+                "entity_count": 0,
+                "disconnected_document_count": 0,
+                "partial_extraction": False,
+                "errors": ["Graph service unavailable"],
+            },
+        }
 
 
 class DocumentResponse(BaseModel):

--- a/backend/app/graph/extractor.py
+++ b/backend/app/graph/extractor.py
@@ -73,37 +73,153 @@ class GraphExtractor:
         return results
 
     async def get_full_graph(self):
-        nodes = []
-        links = []
-        node_ids = set()
-        
+        graph = await self.get_topology_with_health()
+        return {"nodes": graph["nodes"], "links": graph["links"]}
+
+    def _empty_graph(self, status: str, neo4j_available: bool, errors: list[str] | None = None):
+        return {
+            "nodes": [],
+            "links": [],
+            "health": {
+                "status": status,
+                "neo4j_available": neo4j_available,
+                "node_count": 0,
+                "relationship_count": 0,
+                "document_count": 0,
+                "chunk_count": 0,
+                "entity_count": 0,
+                "disconnected_document_count": 0,
+                "partial_extraction": False,
+                "errors": errors or [],
+            },
+        }
+
+    async def get_topology_with_health(self):
+        nodes: list[dict] = []
+        links: list[dict] = []
+        node_ids: set[str] = set()
+        errors: list[str] = []
+
         async with self.driver.session() as session:
             try:
-                # Get all entities and relationships
+                connectivity = await session.run("RETURN 1 AS ok")
+                await connectivity.consume()
+
                 result = await session.run(
-                    "MATCH (n:Entity)-[r]->(m:Entity) RETURN n.id as source, type(r) as type, m.id as target LIMIT 200"
+                    """
+                    MATCH (n)-[r]->(m)
+                    RETURN labels(n) AS source_labels,
+                           coalesce(n.id, n.name, elementId(n)) AS source_id,
+                           coalesce(n.filename, n.title, n.id, elementId(n)) AS source_label,
+                           type(r) AS type,
+                           labels(m) AS target_labels,
+                           coalesce(m.id, m.name, elementId(m)) AS target_id,
+                           coalesce(m.filename, m.title, m.id, elementId(m)) AS target_label
+                    LIMIT 300
+                    """
                 )
                 async for record in result:
-                    source = record["source"]
-                    target = record["target"]
+                    source = str(record["source_id"])
+                    target = str(record["target_id"])
                     rel_type = record["type"]
-                    
+
                     if source not in node_ids:
-                        nodes.append({"id": source, "label": source, "group": 1})
+                        source_type = self._node_type(record["source_labels"])
+                        nodes.append({
+                            "id": source,
+                            "label": record["source_label"] or source,
+                            "type": source_type,
+                            "group": source_type,
+                        })
                         node_ids.add(source)
                     if target not in node_ids:
-                        nodes.append({"id": target, "label": target, "group": 2})
+                        target_type = self._node_type(record["target_labels"])
+                        nodes.append({
+                            "id": target,
+                            "label": record["target_label"] or target,
+                            "type": target_type,
+                            "group": target_type,
+                        })
                         node_ids.add(target)
-                        
+
                     links.append({
                         "source": source,
                         "target": target,
                         "type": rel_type
                     })
+
+                isolated_documents = await session.run(
+                    """
+                    MATCH (d:Document)
+                    WHERE NOT (d)--()
+                    RETURN coalesce(d.id, elementId(d)) AS id,
+                           coalesce(d.filename, d.title, d.id, elementId(d)) AS label
+                    LIMIT 100
+                    """
+                )
+                async for record in isolated_documents:
+                    document_id = str(record["id"])
+                    if document_id in node_ids:
+                        continue
+                    nodes.append({
+                        "id": document_id,
+                        "label": record["label"] or document_id,
+                        "type": "document",
+                        "group": "document",
+                        "connected": False,
+                    })
+                    node_ids.add(document_id)
             except Exception as e:
                 logger.error(f"Failed to fetch full graph: {e}")
-                
-        return {"nodes": nodes, "links": links}
+                return self._empty_graph("unavailable", False, ["Neo4j unavailable"])
+
+        counts = self._count_nodes(nodes)
+        partial_extraction = bool(nodes) and (counts["document_count"] == 0 or counts["entity_count"] == 0)
+        status = "empty"
+        if nodes:
+            status = "partial" if partial_extraction else "healthy"
+
+        return {
+            "nodes": nodes,
+            "links": links,
+            "health": {
+                "status": status,
+                "neo4j_available": True,
+                "node_count": len(nodes),
+                "relationship_count": len(links),
+                "document_count": counts["document_count"],
+                "chunk_count": counts["chunk_count"],
+                "entity_count": counts["entity_count"],
+                "disconnected_document_count": counts["disconnected_document_count"],
+                "partial_extraction": partial_extraction,
+                "errors": errors,
+            },
+        }
+
+    def _node_type(self, labels):
+        normalized = {str(label).lower() for label in labels or []}
+        if "document" in normalized:
+            return "document"
+        if "documentchunk" in normalized or "chunk" in normalized:
+            return "chunk"
+        if "relationship" in normalized:
+            return "relationship"
+        return "entity"
+
+    def _count_nodes(self, nodes: list[dict]):
+        document_count = sum(1 for node in nodes if node.get("type") == "document")
+        chunk_count = sum(1 for node in nodes if node.get("type") == "chunk")
+        entity_count = sum(1 for node in nodes if node.get("type") == "entity")
+        disconnected_document_count = sum(
+            1 for node in nodes
+            if node.get("type") == "document" and not node.get("connected", True)
+        )
+        return {
+            "document_count": document_count,
+            "chunk_count": chunk_count,
+            "entity_count": entity_count,
+            "disconnected_document_count": disconnected_document_count,
+        }
 
     async def close(self):
         await self.driver.close()

--- a/backend/tests/integration/test_graph_endpoint.py
+++ b/backend/tests/integration/test_graph_endpoint.py
@@ -1,0 +1,75 @@
+from fastapi.testclient import TestClient
+
+from app.graph.extractor import graph_extractor
+from app.main import app
+
+
+def test_graph_endpoint_returns_health_and_topology(monkeypatch):
+    async def fake_graph():
+        return {
+            "nodes": [
+                {"id": "doc-1", "label": "handbook.pdf", "type": "document"},
+                {"id": "chunk-1", "label": "Chunk 1", "type": "chunk"},
+                {"id": "entity-1", "label": "Policy", "type": "entity"},
+            ],
+            "links": [
+                {"source": "doc-1", "target": "chunk-1", "type": "HAS_CHUNK"},
+                {"source": "chunk-1", "target": "entity-1", "type": "MENTIONS"},
+            ],
+            "health": {
+                "status": "healthy",
+                "neo4j_available": True,
+                "node_count": 3,
+                "relationship_count": 2,
+                "document_count": 1,
+                "chunk_count": 1,
+                "entity_count": 1,
+                "disconnected_document_count": 0,
+                "partial_extraction": False,
+                "errors": [],
+            },
+        }
+
+    monkeypatch.setattr(graph_extractor, "get_topology_with_health", fake_graph)
+    client = TestClient(app)
+
+    response = client.get("/api/v1/documents/graph")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["health"]["status"] == "healthy"
+    assert data["health"]["neo4j_available"] is True
+    assert {node["type"] for node in data["nodes"]} == {"document", "chunk", "entity"}
+    assert {link["type"] for link in data["links"]} == {"HAS_CHUNK", "MENTIONS"}
+
+
+def test_graph_endpoint_handles_neo4j_unavailable(monkeypatch):
+    async def unavailable_graph():
+        return {
+            "nodes": [],
+            "links": [],
+            "health": {
+                "status": "unavailable",
+                "neo4j_available": False,
+                "node_count": 0,
+                "relationship_count": 0,
+                "document_count": 0,
+                "chunk_count": 0,
+                "entity_count": 0,
+                "disconnected_document_count": 0,
+                "partial_extraction": False,
+                "errors": ["Neo4j unavailable"],
+            },
+        }
+
+    monkeypatch.setattr(graph_extractor, "get_topology_with_health", unavailable_graph)
+    client = TestClient(app)
+
+    response = client.get("/api/v1/documents/graph")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["health"]["status"] == "unavailable"
+    assert data["health"]["neo4j_available"] is False
+    assert "password" not in response.text.lower()
+    assert "bolt://" not in response.text

--- a/frontend/src/app/graph/graphHealth.js
+++ b/frontend/src/app/graph/graphHealth.js
@@ -1,0 +1,63 @@
+export function normalizeGraphPayload(payload) {
+  return {
+    nodes: Array.isArray(payload?.nodes) ? payload.nodes : [],
+    links: Array.isArray(payload?.links) ? payload.links : [],
+    health: payload?.health || {},
+  };
+}
+
+export function getGraphHealthState(graph) {
+  const normalized = normalizeGraphPayload(graph);
+  const health = normalized.health;
+
+  if (health.status === "unavailable" || health.neo4j_available === false) {
+    return {
+      status: "unavailable",
+      title: "Neo4j unavailable",
+      message: "Graph topology cannot be loaded right now.",
+    };
+  }
+
+  if (health.status === "partial" || health.partial_extraction) {
+    return {
+      status: "partial",
+      title: "Partial extraction",
+      message: "Some documents or entities are missing from the graph.",
+    };
+  }
+
+  if (normalized.nodes.length === 0) {
+    return {
+      status: "empty",
+      title: "Graph is empty",
+      message: "No graph nodes or relationships have been extracted yet.",
+    };
+  }
+
+  return {
+    status: "healthy",
+    title: "Graph healthy",
+    message: "Knowledge graph topology is available.",
+  };
+}
+
+export function getGraphNodeColor(node) {
+  switch (node?.type) {
+    case "document":
+      return "#2563eb";
+    case "chunk":
+      return "#059669";
+    case "entity":
+      return "#f0c419";
+    case "relationship":
+      return "#7c3aed";
+    default:
+      return "#121212";
+  }
+}
+
+export function getGraphLinkColor(link) {
+  if (link?.type === "HAS_CHUNK") return "#93c5fd";
+  if (link?.type === "MENTIONS") return "#86efac";
+  return "#d6d3d1";
+}

--- a/frontend/src/app/graph/page.tsx
+++ b/frontend/src/app/graph/page.tsx
@@ -1,30 +1,106 @@
 "use client";
 
-import { useEffect, useState, useRef, useMemo } from "react";
+import { useEffect, useRef, useState } from "react";
 import dynamic from "next/dynamic";
-import { motion } from "framer-motion";
-import { Network, Zap, Cpu, Activity, Shield, Box } from "lucide-react";
+import { Activity, AlertTriangle, Cpu, FileText, Layers, Network, Shield, Zap } from "lucide-react";
+import {
+  getGraphHealthState,
+  getGraphLinkColor,
+  getGraphNodeColor,
+  normalizeGraphPayload,
+} from "./graphHealth";
 
-// Use dynamic import for ForceGraph2D to avoid SSR issues
 const ForceGraph2D = dynamic(() => import("react-force-graph-2d"), { ssr: false });
 
+type GraphNode = {
+  id: string;
+  label?: string;
+  type?: string;
+  x?: number;
+  y?: number;
+};
+
+type GraphLink = {
+  source: string;
+  target: string;
+  type?: string;
+};
+
+type GraphHealth = {
+  status?: string;
+  neo4j_available?: boolean;
+  node_count?: number;
+  relationship_count?: number;
+  document_count?: number;
+  chunk_count?: number;
+  entity_count?: number;
+  disconnected_document_count?: number;
+  partial_extraction?: boolean;
+};
+
+type GraphPayload = {
+  nodes: GraphNode[];
+  links: GraphLink[];
+  health: GraphHealth;
+};
+
 export default function GraphPage() {
-  const [graphData, setGraphData] = useState({ nodes: [], links: [] });
+  const [graphData, setGraphData] = useState<GraphPayload>({ nodes: [], links: [], health: {} });
   const [loading, setLoading] = useState(true);
-  const fgRef = useRef<any>();
+  const [error, setError] = useState<string | null>(null);
+  const fgRef = useRef<{ zoomToFit?: (duration?: number, padding?: number) => void } | null>(null);
 
   useEffect(() => {
-    fetch("/nexus-proxy/documents/graph")
-      .then(res => res.json())
-      .then(data => {
-        setGraphData(data);
-        setLoading(false);
-      });
+    let cancelled = false;
+
+    async function loadGraph() {
+      try {
+        const res = await fetch("/nexus-proxy/v1/documents/graph");
+        const data = await res.json();
+        if (cancelled) return;
+        setGraphData(normalizeGraphPayload(data));
+        setError(res.ok ? null : "Graph endpoint returned an error.");
+      } catch {
+        if (cancelled) return;
+        setGraphData(normalizeGraphPayload({
+          health: { status: "unavailable", neo4j_available: false },
+        }));
+        setError("Graph endpoint could not be reached.");
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    loadGraph();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
-  const nodeColor = (node: any) => {
-    if (node.type === "Entity") return "#fdd029"; // Secondary/Gold
-    return "#121212"; // Primary/Dark
+  const healthState = getGraphHealthState(graphData);
+  const metrics = graphData.health || {};
+  const isGraphVisible = !loading && graphData.nodes.length > 0 && healthState.status !== "unavailable";
+
+  const focusLayout = () => {
+    fgRef.current?.zoomToFit?.(500, 60);
+  };
+
+  const drawNode = (node: GraphNode, ctx: CanvasRenderingContext2D, globalScale: number) => {
+    const label = node.label || node.id;
+    const fontSize = Math.max(10 / globalScale, 3);
+    const radius = node.type === "document" ? 7 : node.type === "chunk" ? 5 : 6;
+
+    ctx.beginPath();
+    ctx.arc(node.x ?? 0, node.y ?? 0, radius, 0, 2 * Math.PI, false);
+    ctx.fillStyle = getGraphNodeColor(node);
+    ctx.fill();
+    ctx.font = `${fontSize}px Inter, sans-serif`;
+    ctx.textAlign = "center";
+    ctx.textBaseline = "top";
+    ctx.fillStyle = "rgba(18,18,18,0.72)";
+    ctx.fillText(label, node.x ?? 0, (node.y ?? 0) + radius + 2);
   };
 
   return (
@@ -32,78 +108,141 @@ export default function GraphPage() {
       <div className="flex items-center justify-between pb-8 border-b border-on-surface/5">
         <div className="space-y-3">
           <div className="flex items-center gap-3 text-secondary">
-             <Network size={24} className="animate-pulse-slow" />
-             <span className="label-sm tracking-[0.6em] font-black uppercase">GraphRAG Topology</span>
+            <Network size={24} className="animate-pulse-slow" />
+            <span className="label-sm tracking-[0.6em] font-black uppercase">GraphRAG Topology</span>
           </div>
           <h1 className="display-md text-on-surface tracking-tighter">Neural Connectivity</h1>
         </div>
         <div className="flex gap-4">
-           <div className="px-6 py-3 bg-primary-container text-secondary rounded-full border border-secondary/20 flex items-center gap-3">
-              <Zap size={14} />
-              <span className="label-sm tracking-[0.1em]">REAL-TIME MAPPING</span>
-           </div>
+          <div className={`px-6 py-3 rounded-full border flex items-center gap-3 ${
+            healthState.status === "healthy"
+              ? "bg-primary-container text-secondary border-secondary/20"
+              : healthState.status === "partial"
+                ? "bg-yellow-50 text-yellow-700 border-yellow-200"
+                : "bg-red-50 text-red-600 border-red-100"
+          }`}>
+            <Zap size={14} />
+            <span className="label-sm tracking-[0.1em] uppercase">{healthState.title}</span>
+          </div>
         </div>
       </div>
 
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-5">
+        <MetricCard label="Documents" value={metrics.document_count ?? 0} icon={FileText} />
+        <MetricCard label="Chunks" value={metrics.chunk_count ?? 0} icon={Layers} />
+        <MetricCard label="Entities" value={metrics.entity_count ?? graphData.nodes.length} icon={Cpu} />
+        <MetricCard label="Relationships" value={metrics.relationship_count ?? graphData.links.length} icon={Network} />
+      </div>
+
       <div className="flex-1 bg-surface-container-lowest border border-on-surface/5 relative overflow-hidden group shadow-premium ring-1 ring-secondary/5">
-         <div className="absolute inset-0 z-0 opacity-[0.03] pointer-events-none">
-            <div className="absolute inset-0 bg-[radial-gradient(circle_at_center,_#fdd029_0%,_transparent_70%)]" />
-         </div>
-         
-         <div className="relative z-10 w-full h-full">
-            {!loading && (
-              <ForceGraph2D
-                ref={fgRef}
-                graphData={graphData}
-                nodeLabel="id"
-                nodeColor={nodeColor}
-                linkColor={() => "#efeeeb"}
-                linkWidth={1.5}
-                nodeRelSize={8}
-                backgroundColor="#ffffff"
-                d3VelocityDecay={0.3}
-              />
-            )}
-         </div>
+        <div className="absolute inset-0 z-0 opacity-[0.03] pointer-events-none">
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_center,_#fdd029_0%,_transparent_70%)]" />
+        </div>
 
-         {/* Overlay Module */}
-         <div className="absolute bottom-10 left-10 right-10 flex justify-between items-end pointer-events-none">
-            <div className="p-8 bg-surface/80 backdrop-blur-xl border border-outline-variant shadow-lg max-w-xs space-y-4 pointer-events-auto">
-               <div className="flex items-center gap-3 text-primary">
-                  <Cpu size={18} />
-                  <span className="label-md tracking-widest font-black uppercase text-[11px]">System Analytics</span>
-               </div>
-               <p className="text-secondary font-display text-4xl font-bold tracking-tight">
-                  {graphData.nodes.length} <span className="text-on-surface/20 text-xl font-normal">Entities</span>
-               </p>
-               <div className="w-full h-px bg-on-surface/5" />
-               <div className="flex justify-between items-center text-[9px] font-black tracking-[0.4em] uppercase opacity-40">
-                  <span>Knowledge Triples</span>
-                  <span>{graphData.links.length}</span>
-               </div>
-            </div>
+        <div className="relative z-10 w-full h-full">
+          {isGraphVisible && (
+            <ForceGraph2D
+              ref={fgRef}
+              graphData={graphData}
+              nodeLabel={(node: GraphNode) => `${node.label || node.id} (${node.type || "node"})`}
+              nodeColor={getGraphNodeColor}
+              linkColor={getGraphLinkColor}
+              linkWidth={1.5}
+              nodeRelSize={8}
+              backgroundColor="#ffffff"
+              d3VelocityDecay={0.3}
+              nodeCanvasObject={drawNode}
+              linkDirectionalArrowLength={4}
+              linkDirectionalArrowRelPos={1}
+            />
+          )}
 
-            <div className="flex flex-col gap-4 items-end">
-               <div className="flex gap-4 mb-4">
-                  <LegendItem color="#fdd029" label="Entities" />
-                  <LegendItem color="#121212" label="Relations" />
-               </div>
-               <div className="px-8 py-4 bg-primary text-secondary rounded-full shadow-2xl flex items-center gap-4 border border-secondary/20 font-black tracking-widest uppercase text-[10px] pointer-events-auto cursor-pointer hover:scale-105 active:scale-95 transition-all">
-                  <Activity size={14} />
-                  Optimize Layout
-               </div>
+          {!isGraphVisible && (
+            <div className="h-full flex flex-col items-center justify-center text-center gap-6 p-12">
+              {loading ? (
+                <>
+                  <Activity size={44} className="text-secondary animate-pulse" />
+                  <div>
+                    <p className="label-md tracking-[0.4em] uppercase opacity-40">Loading topology</p>
+                    <p className="text-sm opacity-40 mt-2">Reading graph health and relationships.</p>
+                  </div>
+                </>
+              ) : (
+                <>
+                  <AlertTriangle size={44} className={healthState.status === "unavailable" ? "text-red-500" : "text-secondary"} />
+                  <div className="max-w-md">
+                    <p className="text-2xl font-display text-on-surface">{healthState.title}</p>
+                    <p className="text-sm opacity-50 mt-3 leading-relaxed">
+                      {error || healthState.message}
+                    </p>
+                  </div>
+                </>
+              )}
             </div>
-         </div>
+          )}
+        </div>
+
+        <div className="absolute bottom-10 left-10 right-10 flex justify-between items-end pointer-events-none">
+          <div className="p-8 bg-surface/80 backdrop-blur-xl border border-outline-variant shadow-lg max-w-xs space-y-4 pointer-events-auto">
+            <div className="flex items-center gap-3 text-primary">
+              <Shield size={18} />
+              <span className="label-md tracking-widest font-black uppercase text-[11px]">Graph Health</span>
+            </div>
+            <p className="text-secondary font-display text-4xl font-bold tracking-tight">
+              {metrics.node_count ?? graphData.nodes.length} <span className="text-on-surface/20 text-xl font-normal">Nodes</span>
+            </p>
+            <div className="w-full h-px bg-on-surface/5" />
+            <div className="space-y-2 text-[9px] font-black tracking-[0.25em] uppercase opacity-50">
+              <div className="flex justify-between items-center">
+                <span>Disconnected Docs</span>
+                <span>{metrics.disconnected_document_count ?? 0}</span>
+              </div>
+              <div className="flex justify-between items-center">
+                <span>Partial Extraction</span>
+                <span>{metrics.partial_extraction ? "YES" : "NO"}</span>
+              </div>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-4 items-end">
+            <div className="flex flex-wrap gap-4 mb-4 justify-end">
+              <LegendItem color="#2563eb" label="Documents" />
+              <LegendItem color="#059669" label="Chunks" />
+              <LegendItem color="#f0c419" label="Entities" />
+              <LegendItem color="#7c3aed" label="Relationships" />
+            </div>
+            <button
+              type="button"
+              onClick={focusLayout}
+              className="px-8 py-4 bg-primary text-secondary rounded-full shadow-2xl flex items-center gap-4 border border-secondary/20 font-black tracking-widest uppercase text-[10px] pointer-events-auto cursor-pointer hover:scale-105 active:scale-95 transition-all"
+            >
+              <Activity size={14} />
+              Optimize Layout
+            </button>
+          </div>
+        </div>
       </div>
     </div>
   );
 }
 
-function LegendItem({ color, label }: any) {
+function MetricCard({ label, value, icon: Icon }: { label: string; value: number; icon: typeof Network }) {
+  return (
+    <div className="bg-surface border border-on-surface/5 shadow-premium p-5 flex items-center justify-between">
+      <div>
+        <p className="label-sm text-[9px] tracking-[0.3em] opacity-35 uppercase">{label}</p>
+        <p className="text-2xl font-display text-on-surface mt-1">{value}</p>
+      </div>
+      <Icon size={18} className="text-secondary" />
+    </div>
+  );
+}
+
+function LegendItem({ color, label }: { color: string; label: string }) {
   return (
     <div className="flex items-center gap-3 bg-surface/60 backdrop-blur-md px-5 py-2.5 rounded-full border border-outline-variant">
-       <div className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: color }} />
-       <span className="label-sm opacity-60 text-[9px] tracking-widest">{label}</span>
+      <div className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: color }} />
+      <span className="label-sm opacity-60 text-[9px] tracking-widest">{label}</span>
     </div>
   );
 }

--- a/frontend/tests/graphHealth.test.mjs
+++ b/frontend/tests/graphHealth.test.mjs
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  getGraphHealthState,
+  getGraphNodeColor,
+  normalizeGraphPayload,
+} from "../src/app/graph/graphHealth.js";
+
+test("normalizes missing graph payload into empty state", () => {
+  const graph = normalizeGraphPayload(null);
+
+  assert.deepEqual(graph.nodes, []);
+  assert.deepEqual(graph.links, []);
+  assert.equal(getGraphHealthState(graph).status, "empty");
+});
+
+test("classifies unavailable and partial graph health", () => {
+  assert.equal(
+    getGraphHealthState({
+      nodes: [],
+      links: [],
+      health: { status: "unavailable", neo4j_available: false },
+    }).status,
+    "unavailable",
+  );
+
+  assert.equal(
+    getGraphHealthState({
+      nodes: [{ id: "doc-1", type: "document" }],
+      links: [],
+      health: { status: "partial", partial_extraction: true },
+    }).status,
+    "partial",
+  );
+});
+
+test("maps graph node types to distinct colors", () => {
+  assert.equal(getGraphNodeColor({ type: "document" }), "#2563eb");
+  assert.equal(getGraphNodeColor({ type: "chunk" }), "#059669");
+  assert.equal(getGraphNodeColor({ type: "entity" }), "#f0c419");
+  assert.equal(getGraphNodeColor({ type: "relationship" }), "#7c3aed");
+});


### PR DESCRIPTION
## 📝 Description
Adds an admin-facing knowledge graph topology and health view so admins can inspect documents, chunks, entities, relationships, disconnected documents, and graph extraction status.

Related to SAI-16

## 🎯 Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## 🧪 Testing
Describe how you tested these changes:
- [ ] Manual testing (describe steps)
- [x] Added unit tests
- [x] Added integration tests
- [ ] Tested on local Docker stack

### Test Results
```
pytest -q backend/tests/integration/test_graph_endpoint.py
2 passed, 53 warnings in 0.09s

node --test --no-warnings frontend/tests/graphHealth.test.mjs
3 passed

npx eslint src/app/graph/page.tsx
passed with no output

cd backend && pytest -q
38 passed, 167 warnings in 2.11s

cd frontend && npm run build
Compiled successfully, then failed during TypeScript validation due to existing unrelated issue:
frontend/src/app/approve/[...slug]/page is missing a default export.
```

## ✅ Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Comments added for complex logic
- [ ] Documentation updated
- [ ] No new warnings generated
- [x] Tests added/updated and passing
- [ ] Screenshots/GIFs added (for UI changes)

## 📸 Screenshots (if applicable)
Not captured.

## 🔄 Deployment Notes
Any deployment considerations or breaking changes:
- [ ] Database migrations needed
- [ ] Environment variables required
- [ ] Configuration changes needed

No database migrations, environment variable changes, or configuration changes are required.
