### PR TITLE
feat(api): add OpenAI-compatible chat endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,9 @@ EMBEDDING_MODEL=all-MiniLM-L6-v2
 # API Keys (Update with your actual keys)
 OPENAI_API_KEY=your-openai-api-key-here
 
+# LLM provider base URL (OpenAI-compatible; e.g. Ollama at http://localhost:11434)
+LLM_BASE_URL=http://localhost:11434
+
 # Redis Configuration
 REDIS_URL=redis://redis:6379/0
 

--- a/backend/app/api/openai_compatible.py
+++ b/backend/app/api/openai_compatible.py
@@ -1,0 +1,12 @@
+from fastapi import APIRouter, Request
+
+from app.services.openai_compatible_adapter import forward_chat_completion
+
+router = APIRouter(tags=["openai-compatible"])
+
+
+@router.post("/chat/completions")
+async def chat_completions(request: Request):
+    body = await request.json()
+    authorization = request.headers.get("Authorization")
+    return await forward_chat_completion(body, authorization)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -28,6 +28,7 @@ class Settings(BaseSettings):
     RERANKING_MODEL: str = os.getenv("RERANKING_MODEL", "cross-encoder/ms-marco-MiniLM-L-6-v2")
     LLM_PROVIDER: str = os.getenv("LLM_PROVIDER", "openai")
     OPENAI_API_KEY: str = os.getenv("OPENAI_API_KEY", "")
+    LLM_BASE_URL: str = os.getenv("LLM_BASE_URL", "http://localhost:11434")
     
     # Retrieval Limits
     DEFAULT_TOP_K: int = 5

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -27,7 +27,7 @@ app.add_middleware(
 )
 
 # Import and include routers
-from app.api import documents, chat, settings as settings_route, auth, users, approval
+from app.api import documents, chat, settings as settings_route, auth, users, approval, openai_compatible
 
 app.include_router(auth.router, prefix=settings.API_V1_STR)
 app.include_router(users.router, prefix=settings.API_V1_STR)
@@ -35,6 +35,7 @@ app.include_router(approval.router, prefix=settings.API_V1_STR)
 app.include_router(documents.router, prefix=settings.API_V1_STR)
 app.include_router(chat.router, prefix=settings.API_V1_STR)
 app.include_router(settings_route.router, prefix=settings.API_V1_STR)
+app.include_router(openai_compatible.router, prefix="/v1")
 
 @app.get("/api/health")
 async def health_check():

--- a/backend/app/services/openai_compatible_adapter.py
+++ b/backend/app/services/openai_compatible_adapter.py
@@ -1,0 +1,28 @@
+from typing import Any, Optional
+
+import httpx
+from fastapi import HTTPException
+
+from app.core.config import settings
+
+
+async def forward_chat_completion(
+    body: dict[str, Any],
+    authorization: Optional[str] = None,
+) -> dict[str, Any]:
+    url = f"{settings.LLM_BASE_URL.rstrip('/')}/v1/chat/completions"
+    headers: dict[str, str] = {}
+    if authorization:
+        headers["Authorization"] = authorization
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(url, json=body, headers=headers, timeout=60.0)
+
+    if response.is_error:
+        try:
+            detail = response.json()
+        except ValueError:
+            detail = response.text or response.reason_phrase
+        raise HTTPException(status_code=response.status_code, detail=detail)
+
+    return response.json()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -44,6 +44,7 @@ def test_db():
     Base.metadata.create_all(bind=engine)
     yield engine
 
+    engine.dispose()
     import os
     os.unlink(db_path)
 

--- a/backend/tests/integration/test_openai_compatible.py
+++ b/backend/tests/integration/test_openai_compatible.py
@@ -1,0 +1,74 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.core.config import settings
+from app.main import app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def test_chat_completions_forwards_to_provider(client, monkeypatch):
+    monkeypatch.setattr(settings, "LLM_BASE_URL", "http://fake-provider.local")
+
+    provider_response = {
+        "id": "chatcmpl-test",
+        "object": "chat.completion",
+        "created": 1234567890,
+        "model": "llama3.2",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "Hello!"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15,
+        },
+    }
+
+    mock_http_response = MagicMock()
+    mock_http_response.is_error = False
+    mock_http_response.status_code = 200
+    mock_http_response.json.return_value = provider_response
+
+    mock_http_client = AsyncMock()
+    mock_http_client.post = AsyncMock(return_value=mock_http_response)
+    mock_http_client.__aenter__ = AsyncMock(return_value=mock_http_client)
+    mock_http_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch(
+        "app.services.openai_compatible_adapter.httpx.AsyncClient",
+        return_value=mock_http_client,
+    ):
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "llama3.2",
+                "messages": [{"role": "user", "content": "hello"}],
+                "stream": False,
+            },
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["object"] == "chat.completion"
+    assert data["choices"][0]["message"]["content"] == "Hello!"
+    assert "usage" in data
+
+    mock_http_client.post.assert_called_once()
+    call_kwargs = mock_http_client.post.call_args.kwargs
+    assert mock_http_client.post.call_args.args[0] == "http://fake-provider.local/v1/chat/completions"
+    assert call_kwargs["json"] == {
+        "model": "llama3.2",
+        "messages": [{"role": "user", "content": "hello"}],
+        "stream": False,
+    }
+    assert "headers" not in call_kwargs or "Authorization" not in call_kwargs.get("headers", {})


### PR DESCRIPTION
Fixes #25

## Summary

- Added an OpenAI-compatible `POST /v1/chat/completions` endpoint
- Added `LLM_BASE_URL` provider configuration with an Ollama-friendly default
- Forwarded chat completion requests to `{LLM_BASE_URL}/v1/chat/completions`
- Preserved optional incoming `Authorization` headers without requiring an API key
- Added an integration test with a mocked provider request
- Disposed the test SQLite engine before cleanup to avoid Windows file-lock teardown errors

## Testing

- Ran `python -m pytest tests/integration/test_openai_compatible.py -v`

Result: `1 passed, 4 warnings`

The warnings are existing Pydantic deprecation warnings unrelated to this change.

## Notes

For local Ollama usage, set `LLM_BASE_URL=http://localhost:11434`.

Then send requests to `POST http://localhost:8001/v1/chat/completions`.

No OpenAI API key is required for this endpoint.